### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Twisp](http://i.imgbox.com/52TO2ziT.png)
 
 [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/maxmouchet/twisp/blob/master/LICENSE)
-[![Docker Pulls](https://img.shields.io/docker/pulls/maxmouchet/twisp.svg?maxAge=2592000&style=flat-square)](https://hub.docker.com/r/maxmouchet/twisp/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/maxmouchet/twisp.svg?maxAge=2592000&style=flat-square)](https://hub.docker.com/r/maxmouchet/twisp/) [![](https://images.microbadger.com/badges/image/maxmouchet/twisp.svg)](https://microbadger.com/images/maxmouchet/twisp "Get your own image badge on microbadger.com")
 [![Travis](https://img.shields.io/travis/maxmouchet/twisp.svg?maxAge=2592000&style=flat-square)](https://travis-ci.org/maxmouchet/twisp)
 
 
@@ -62,3 +62,4 @@ Requirements:
 - Elixir 1.2+
 - PostgreSQL 9.3+
 
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [maxmouchet/twisp](https://hub.docker.com/r/maxmouchet/twisp/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/maxmouchet/twisp).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/maxmouchet/twisp.svg)](https://microbadger.com/images/maxmouchet/twisp "Get your own image badge on microbadger.com")
